### PR TITLE
Align header style with CV page

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
       rel="stylesheet"
     />
 
+    <link rel="stylesheet" href="assets/styles.css" />
     <style>
       :root {
 
@@ -35,8 +36,15 @@
         animation: fadeIn 1s ease-in;
         overflow-x: hidden;
       }
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
+      }
 
-    <link rel="stylesheet" href="assets/styles.css" />
 
       nav {
         background: linear-gradient(90deg, #ff512f, #dd2476);


### PR DESCRIPTION
## Summary
- Load shared stylesheet correctly on the main page
- Add missing fade-in animation so navigation bar matches CV theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689df8e9b9c08320b7810e66b437fb95